### PR TITLE
Migrate C++ toolchains to bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+build --enable_bzlmod
+
 # Use the earliest supported C++ version for protoc.
 build --cxxopt=-std=c++14 --host_cxxopt=-std=c++14
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,17 @@
+module(
+    name = "nativelink",
+    version = "0.0.0",
+    compatibility_level = 0,
+)
+
+register_execution_platforms(
+    "@nativelink//local-remote-execution/generated/config:platform",
+)
+
+register_toolchains(
+    "@nativelink//local-remote-execution/generated/config:cc-toolchain",
+    "@nativelink//local-remote-execution/generated/java:all",
+)
+
+bazel_dep(name = "platforms", version = "0.0.8")
+bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -3,35 +3,10 @@ workspace(name = "nativelink")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "rules_cc",
-    sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
-    strip_prefix = "rules_cc-0.0.9",
-    urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
-)
-
-register_execution_platforms(
-    "@nativelink//local-remote-execution/generated/config:platform",
-)
-
-register_toolchains(
-    "@nativelink//local-remote-execution/generated/config:cc-toolchain",
-    "@nativelink//local-remote-execution/generated/java:all",
-)
-
-http_archive(
     name = "rules_rust",
     sha256 = "36ab8f9facae745c9c9c1b33d225623d976e78f2cc3f729b7973d8c20934ab95",
     urls = [
         "https://github.com/bazelbuild/rules_rust/releases/download/0.31.0/rules_rust-v0.31.0.tar.gz",
-    ],
-)
-
-http_archive(
-    name = "rules_python",
-    sha256 = "84aec9e21cc56fbc7f1335035a71c850d1b9b5cc6ff497306f84cced9a769841",
-    strip_prefix = "rules_python-0.23.1",
-    urls = [
-        "https://github.com/bazelbuild/rules_python/releases/download/0.23.1/rules_python-0.23.1.tar.gz",
     ],
 )
 


### PR DESCRIPTION
For unknown reasons this behaves better with toolchain resolution and unbreaks the Bazel build on Windows.

# Description

Please include a summary of the changes and the related issue. Please also
include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please also list any relevant details for your test configuration

## Checklist

- [ ] Updated documentation if needed
- [ ] Tests added/amended
- [ ] `bazel test //...`  passes locally
- [ ] PR is contained in a single commit, using `git amend` see some [docs](https://www.atlassian.com/git/tutorials/rewriting-history)
