### PR TITLE
Serialize workflows using Nix caching

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -28,9 +28,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Cache Nix derivations TODO(aaronmondal): revisit this bit when there are less flakes or it is more understood
-        # uses: >- # Custom commit, last pinned at 2023-11-17.
-          # DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
+      # TODO(aaronmondal): Caching is flaky for this workflow.
+      # See: https://github.com/DeterminateSystems/magic-nix-cache/issues/32
+      # - name: Cache Nix derivations
+      #   uses: >- # Custom commit, last pinned at 2023-11-17.
+      #     DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
 
       - name: Test image
         run: |

--- a/.github/workflows/lre.yaml
+++ b/.github/workflows/lre.yaml
@@ -55,9 +55,11 @@ jobs:
         uses: >- #v7
           DeterminateSystems/nix-installer-action@5620eb4af6b562c53e4d4628c0b6e4f9d9ae8612
 
-      - name: Cache Nix derivations
-        uses: >- # Custom commit, last pinned at 2023-11-17.
-          DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
+      # TODO(aaronmondal): Caching is flaky for this workflow.
+      # See: https://github.com/DeterminateSystems/magic-nix-cache/issues/32
+      # - name: Cache Nix derivations
+      #   uses: >- # Custom commit, last pinned at 2023-11-17.
+      #     DeterminateSystems/magic-nix-cache-action@a04e6275a6bea232cd04fc6f3cbf20d4cb02a3e1
 
       - name: Start Kubernetes cluster (Infra)
         run: >


### PR DESCRIPTION
Alleviates the pressure on the GitHub action cache by only allowing a single nix-caching job at a time.

Fixes #464
Fixes #611