### PR TITLE
Fix overflowing mermaid diagrams in docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -63,7 +63,7 @@ export default defineConfig({
     sitemap(),
     starlight({
       components: {
-        PagekFrame: "./src/components/PageFrame.astro",
+        PageFrame: "./src/components/PageFrame.astro",
       },
       logo: {
         light: "/src/assets/logo-light.svg",


### PR DESCRIPTION
Turns out I added this already and it just didn't work because of a typo.